### PR TITLE
ci(npmpublish.yml): fix no campo runs-on de test [skip ci] 

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,7 +17,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubunt-latest
+    runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Corrige a propriedade runs-on no arquivo de configuração de atualização do pacote no npm