### PR TITLE
fix(enums.ts): correção de enum DISCOVER

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -22,7 +22,8 @@ export enum EnumBrands {
   AURA = 'AURA',
   JCB = 'JCB',
   DINERS = 'DINERS',
-  DISCOVERY = 'DISCOVERY',
+  DISCOVERY = 'DISCOVER',
+  DISCOVER = 'DISCOVER',
   HIPERCARD = 'HIPERCARD'
 }
 


### PR DESCRIPTION
Corrige o enum DISCOVERY para o valor DISCOVER. Enum antigo foi mantido por questão de
compatibilidade e foi adicionado um novo com o valor correto.

#85