### PR TITLE
fix: (Antifraude) Ajustes para retornar code e message para bad request

### DIFF
--- a/src/class/utils.ts
+++ b/src/class/utils.ts
@@ -58,11 +58,13 @@ export class Utils {
     } as IHttpRequestOptions;
   }
 
-  private parseHttpRequestError(options: IHttpRequestOptions, data: string, response: any): IHttpRequestReject {
+  private parseHttpRequestError(options: IHttpRequestOptions, data: string, responseHttp: any, responseCielo: any ): IHttpRequestReject {
+    responseHttp.Code = (Array.isArray(responseCielo) && responseCielo[0] && responseCielo[0].Code) || '';
+    responseHttp.Message = (Array.isArray(responseCielo) && responseCielo[0] && responseCielo[0].Message) || '';
     return {
-      statusCode: response.statusCode || '',
-      request: JSON.stringify(data).toString(),
-      response: response
+      statusCode: responseHttp.statusCode || '',
+      request: JSON.stringify(data).toString(),      
+      response: responseHttp
     } as IHttpRequestReject;
   }
 
@@ -85,7 +87,7 @@ export class Utils {
     
         res.on('end', () => {
           const response = (chunks.length > 0 && this.validateJSON(chunks)) ? JSON.parse(chunks) : '';
-          if (res.statusCode && [200, 201].indexOf(res.statusCode) === -1) return reject(this.parseHttpRequestError(options, data, res));
+          if (res.statusCode && [200, 201].indexOf(res.statusCode) === -1) return reject(this.parseHttpRequestError(options, data, res, response));
           if (options.method === 'PUT' && chunks.length === 0) return resolve(this.parseHttpPutResponse(res));
           return resolve({
             ...this.parseHttpPutResponse(res),


### PR DESCRIPTION
Foi adicionado tratamento para incluir o code e message retornado pela Cielo em caso de Bad Request, o qual pode ser consultado pela tabela https://developercielo.github.io/manual/cielo-ecommerce#c%C3%B3digos-de-erros-da-api